### PR TITLE
chore: sync cluster-base/develop (install @generacy-ai/orchestrator)

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -61,6 +61,7 @@ install_packages() {
         "@generacy-ai/agency-plugin-spec-kit@${CHANNEL}" \
         "@generacy-ai/cluster-relay@${CHANNEL}" \
         "@generacy-ai/control-plane@${CHANNEL}" \
+        "@generacy-ai/orchestrator@${CHANNEL}" \
         2>>"$SETUP_LOG" || { log "ERROR: npm install failed"; exit 1; }
     # Write marker: channel + installed version of generacy
     local version


### PR DESCRIPTION
## Summary

Picks up generacy-ai/cluster-base#43 — adds `@generacy-ai/orchestrator@${CHANNEL}` to the entrypoint's `npm install` list so the orchestrator container can resolve the dynamic `import('@generacy-ai/orchestrator')` introduced by generacy-ai/generacy#674.

Without this sync, any cluster built from a `cluster-microservices`-derived image (including `ghcr.io/painworth/ai-lawfirm/generacy:latest`) crash-loops with "The orchestrator package is not installed."

## Diff against develop

One-line addition in `.devcontainer/generacy/scripts/entrypoint-orchestrator.sh`.

## Test plan

- [x] Manual merge clean (auto-merged via `ort`, no conflicts)
- [x] `git diff develop` shows only the one-line install-list addition
- [ ] After merge, the downstream image consumers rebuild their cluster image and a fresh launch reaches the post-activation watcher

## Related

- generacy-ai/cluster-base#43 — upstream fix this PR syncs
- generacy-ai/generacy#674 — split that introduced the dynamic import

🤖 Generated with [Claude Code](https://claude.com/claude-code)