### PR TITLE
chore: sync cluster-base#49 — cd to WORKSPACE_DIR before exec'ing orchestrator

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -188,6 +188,21 @@ if [ -f "$SECRET_APP_ENV" ]; then
     set +a
 fi
 
+# Ensure the orchestrator process runs with its CWD inside the user's repo.
+# `process.cwd()` is what orchestrator-side file resolution falls back to —
+# /files?path=… (files.ts) and readClusterYaml (relay-bridge.ts) both
+# resolve workspace-relative paths against it. Without this cd, CWD stays
+# at the Dockerfile's WORKDIR (/workspaces) and every workspace-relative
+# read lands one level too high (e.g. /workspaces/.generacy/cluster.yaml
+# instead of /workspaces/<repo>/.generacy/cluster.yaml), which the cloud UI
+# surfaces as "Configuration Not Found".
+if [ -n "${WORKSPACE_DIR:-}" ] && [ -d "$WORKSPACE_DIR" ]; then
+    log "Changing CWD to workspace: $WORKSPACE_DIR"
+    cd "$WORKSPACE_DIR"
+else
+    log "WARNING: WORKSPACE_DIR not set or missing; orchestrator CWD will be $(pwd) — workspace-relative file reads will fail"
+fi
+
 # Start orchestrator as PID 1
 log "Starting orchestrator on port ${ORCHESTRATOR_PORT:-3100}..."
 exec generacy orchestrator \


### PR DESCRIPTION
## Summary
Cherry-picks generacy-ai/cluster-base#50 (commit `9f71087`) — adds a `cd "$WORKSPACE_DIR"` right before the final `exec generacy orchestrator …` so the orchestrator's `process.cwd()` lands inside the user's repo, not at `/workspaces`.

## Why
Without this, every workspace-relative file read from the orchestrator (`/files?path=…` in files.ts, `readClusterYaml` in relay-bridge.ts) resolves one level too high. The cloud UI's Cluster Config tab surfaces this as **"Configuration Not Found"** even when `.generacy/cluster.yaml` is present in the repo.

cluster-microservices ships the same entrypoint pattern as cluster-base and has the same bug.

## Conflict / merge notes
Cherry-pick applied cleanly (auto-merged via `ort`). One file changed:
- `.devcontainer/generacy/scripts/entrypoint-orchestrator.sh` — 15 lines added immediately before the `exec generacy orchestrator` block.

This PR is filed independently of #20 (the in-flight #45+#46 sync) so it can be merged in either order.

## Test plan
- [x] `bash -n` passes on the modified entrypoint
- [x] Diff against `develop` is exactly the 15-line block from cluster-base#50
- [ ] After deploy, `docker exec <orchestrator> readlink -f /proc/1/cwd` returns the repo path, not `/workspaces`
- [ ] Cloud UI's Cluster Config tab loads cluster.yaml content (no "Configuration Not Found")

## Related
- generacy-ai/cluster-base#49 — upstream issue
- generacy-ai/cluster-base#50 — upstream PR this syncs
- #20 — sibling sync PR for cluster-base#45 + #46 (independent; merge order doesn't matter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)