### PR TITLE
chore: sync cluster-base#51 — gitignore .generacy/cluster.local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Runtime state written by the orchestrator — never commit.
+# See generacy-ai/generacy#709: orchestrator now writes runtime mutations
+# (e.g. worker replica count after scale) to cluster.local.yaml instead of
+# the git-tracked cluster.yaml.
+.generacy/cluster.local.yaml


### PR DESCRIPTION
## Summary
Cherry-picks generacy-ai/cluster-base#52 — adds a root `.gitignore` with `.generacy/cluster.local.yaml` so the runtime-state file the orchestrator writes (introduced by generacy-ai/generacy#709) doesn't appear in `git status` or get accidentally committed.

## Why
generacy#709 moved orchestrator runtime mutations (e.g. worker replica count after scale) off the git-tracked `cluster.yaml` and onto a sibling `cluster.local.yaml`. Without an ignore entry in the template repos, every freshly-bootstrapped project surfaces a noisy `?? .generacy/cluster.local.yaml` in `git status` after the first scale.

cluster-microservices ships the same template surface as cluster-base and needs the same ignore.

## Conflict / merge notes
Cherry-pick applied cleanly. One new file:
- `.gitignore` (root) — 5 lines, ignores `.generacy/cluster.local.yaml`

No prior root `.gitignore` to merge with.

## Test plan
- [x] `git check-ignore -v .generacy/cluster.local.yaml` → matches `.gitignore:5`
- [x] Diff against `develop` is exactly the new 5-line file
- [ ] Fresh project bootstrap + worker-scale leaves `git status` clean

## Related
- generacy-ai/cluster-base#51 — upstream issue
- generacy-ai/cluster-base#52 — upstream PR this syncs
- generacy-ai/generacy#709 — the change that introduced `cluster.local.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)