### PR TITLE
chore: sync cluster-base #69 — channel-aware cockpit plugin install

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -89,6 +89,22 @@ install_packages() {
         "@generacy-ai/control-plane@${CHANNEL}" \
         "@generacy-ai/orchestrator@${CHANNEL}" \
         2>>"$SETUP_LOG" || { log "ERROR: npm install failed"; exit 1; }
+
+    # Cockpit Claude Code plugin (generacy-ai/cluster-base#69). Installed as a
+    # separate, best-effort step so it can NOT brick cluster boot: the package
+    # may be absent from a given channel (e.g. before it is published to
+    # ${CHANNEL}), and a missing tag would fail the whole install above. It lands
+    # in the shared-packages volume where `generacy setup build` (G-S5) resolves
+    # it (Tier 2) and copies commands/*.md into ~/.claude/commands/cockpit/,
+    # making /cockpit:* available with no manual marketplace/npm steps.
+    log "Installing @generacy-ai/claude-plugin-cockpit@${CHANNEL} (best-effort) into ${SHARED_PACKAGES}..."
+    npm install \
+        --prefix "${SHARED_PACKAGES}" \
+        --no-save \
+        "@generacy-ai/claude-plugin-cockpit@${CHANNEL}" \
+        2>>"$SETUP_LOG" \
+        || log "WARNING: cockpit plugin install failed (channel: ${CHANNEL}) — /cockpit:* may be unavailable (see $SETUP_LOG)"
+
     # Write marker: channel + installed version of generacy
     local version
     version=$(node -e "console.log(require('${SHARED_PACKAGES}/node_modules/@generacy-ai/generacy/package.json').version)" 2>/dev/null || echo "unknown")

--- a/.devcontainer/generacy/scripts/setup-speckit.sh
+++ b/.devcontainer/generacy/scripts/setup-speckit.sh
@@ -6,6 +6,12 @@
 
 SETUP_LOG="${SETUP_LOG:-/tmp/generacy-setup.log}"
 
+# Release channel for npm installs. GENERACY_CHANNEL is exported by
+# load-cluster-config.sh in the entrypoints that invoke this script, so a
+# preview cluster recovers the preview-channel packages. Mirrors
+# entrypoint-orchestrator.sh's CHANNEL derivation.
+CHANNEL="${GENERACY_CHANNEL:-stable}"
+
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [setup-speckit] $*"
 }
@@ -43,12 +49,22 @@ if [ "$1" = "--verify" ]; then
 fi
 
 # Full setup mode — recover speckit via npm (no git clone needed)
-log "Installing @generacy-ai/agency-plugin-spec-kit from npm..."
-npm install -g @generacy-ai/agency-plugin-spec-kit 2>>"$SETUP_LOG" || {
-    log "ERROR: npm install -g @generacy-ai/agency-plugin-spec-kit failed"
+log "Installing @generacy-ai/agency-plugin-spec-kit@${CHANNEL} from npm..."
+npm install -g "@generacy-ai/agency-plugin-spec-kit@${CHANNEL}" 2>>"$SETUP_LOG" || {
+    log "ERROR: npm install -g @generacy-ai/agency-plugin-spec-kit@${CHANNEL} failed"
     exit 1
 }
 log "agency-plugin-spec-kit installed"
+
+# Cockpit Claude Code plugin (generacy-ai/cluster-base#69). Best-effort: unlike
+# speckit this is an orchestrator-only convenience and NOT required for workers
+# to process phases, so a failure here (e.g. the package not yet published to
+# ${CHANNEL}) must not fail speckit recovery. The `generacy setup build` re-run
+# below wires /cockpit:* from it (G-S5) exactly as it does for speckit.
+log "Installing @generacy-ai/claude-plugin-cockpit@${CHANNEL} from npm (best-effort)..."
+npm install -g "@generacy-ai/claude-plugin-cockpit@${CHANNEL}" 2>>"$SETUP_LOG" \
+    && log "claude-plugin-cockpit installed" \
+    || log "WARNING: npm install -g @generacy-ai/claude-plugin-cockpit@${CHANNEL} failed — /cockpit:* may be unavailable (see $SETUP_LOG)"
 
 # Re-run generacy setup build to trigger Phase 4 (copies command files)
 if command -v generacy >/dev/null 2>&1; then


### PR DESCRIPTION
Syncs [cluster-base#69 / #70](https://github.com/generacy-ai/cluster-base/pull/70) into cluster-microservices, keeping the two cluster image variants' setup scripts in step.

## What syncs in

Installs `@generacy-ai/claude-plugin-cockpit@${CHANNEL}` during cluster setup so `/cockpit:*` is available in a fresh Claude Code session in the orchestrator dev container with zero manual marketplace/npm steps — mirroring how spec-kit is installed.

- **`entrypoint-orchestrator.sh` → `install_packages()`**: happy-path install into the shared-packages volume (Tier 2 for `generacy setup build`'s G-S5 cockpit resolver, which copies `commands/*.md` into `~/.claude/commands/cockpit/`). Runs before the wizard-mode branch, so both devcontainer and wizard/preview clusters get it.
- **`setup-speckit.sh`** (build-failure recovery path): mirrors the cockpit install globally, and aligns the spec-kit recovery install to `${CHANNEL}` (was untagged/`latest`).

Both cockpit installs are best-effort / non-fatal — a package absent from a channel must never brick boot, and `verify_speckit` stays speckit-only so a missing cockpit never trips the worker's fatal `--verify` gate.

## Merge details

Clean auto-merge of `cluster-base/develop` (the only unmerged commit was #69). Net diff is the two setup scripts, +35/-3. Both scripts syntax-checked (`bash -n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)