### PR TITLE
chore: sync cluster-base #71 — fix cockpit install pruning the generacy bin

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -78,6 +78,35 @@ CHANNEL="${GENERACY_CHANNEL:-stable}"
 MARKER_FILE="${SHARED_PACKAGES}/.installed-version"
 
 install_packages() {
+    # Seed a manifest in the shared volume declaring the core packages as
+    # dependencies. /shared-packages has no package.json of its own, so without
+    # this every already-installed package is *extraneous* to npm. The separate
+    # best-effort cockpit install below then reconciles the tree on its own
+    # terms and prunes everything it doesn't depend on — including the core
+    # packages' bin symlinks (notably .bin/generacy). That leaves the final
+    # `exec generacy orchestrator` failing with "generacy: not found" and the
+    # orchestrator in a crash loop, but only on channels where the cockpit
+    # package actually publishes (e.g. preview) so the second install succeeds
+    # and reconciles. Declaring the core packages here keeps them in npm's ideal
+    # tree so the cockpit install can no longer prune them
+    # (generacy-ai/cluster-base#71). Keep this list in sync with the install
+    # command below.
+    log "Seeding ${SHARED_PACKAGES}/package.json to protect core packages from prune..."
+    cat > "${SHARED_PACKAGES}/package.json" <<'EOF'
+{
+  "name": "generacy-shared-packages",
+  "private": true,
+  "dependencies": {
+    "@generacy-ai/generacy": "*",
+    "@generacy-ai/agency": "*",
+    "@generacy-ai/agency-plugin-spec-kit": "*",
+    "@generacy-ai/cluster-relay": "*",
+    "@generacy-ai/control-plane": "*",
+    "@generacy-ai/orchestrator": "*"
+  }
+}
+EOF
+
     log "Installing @generacy-ai packages (channel: ${CHANNEL}) into ${SHARED_PACKAGES}..."
     npm install \
         --prefix "${SHARED_PACKAGES}" \


### PR DESCRIPTION
Syncs the latest `cluster-base/develop` into cluster-microservices.

## What's included

One upstream commit: [`generacy-ai/cluster-base#72`](https://github.com/generacy-ai/cluster-base/pull/72) (fixes [cluster-base#71](https://github.com/generacy-ai/cluster-base/issues/71)).

## Why it matters

Fresh `preview`-channel clusters were crash-looping the orchestrator. `install_packages()` in `entrypoint-orchestrator.sh` ran two `npm install --prefix /shared-packages --no-save` commands into a directory with no `package.json`, so the best-effort cockpit install (added in cluster-base #69) treated the core packages as extraneous and pruned their bin symlinks — including `.bin/generacy`. The final `exec generacy orchestrator` then failed with `generacy: not found` → restart loop. It only bit on channels where cockpit publishes (e.g. `preview`).

The fix seeds a `package.json` into `/shared-packages` declaring the core packages as dependencies before installing, so they stay in npm's ideal tree and the cockpit install can no longer prune them.

## Scope of this merge

Clean 3-way merge off the previous sync (#69). The only applied change is the 29-line fix block in `.devcontainer/generacy/scripts/entrypoint-orchestrator.sh` — no cluster-microservices-specific customizations were touched. `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)