### PR TITLE
chore: sync cluster-base #73 — CLI bins on PATH for interactive & tunnel shells

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -131,6 +131,22 @@ RUN mkdir -p /workspaces && chown -R node:node /workspaces
 # (Docker named volumes default to root, causing EACCES for node user)
 RUN mkdir -p /shared-packages && chown node:node /shared-packages
 
+# Put the user-facing CLIs on PATH for every shell type.
+# The entrypoint's npm install lands the CLI bins in the shared-packages volume
+# (/shared-packages/node_modules/.bin) and exports that dir onto PATH for the
+# entrypoint process ONLY — daemons it spawns inherit it, but interactive shells
+# and the VS Code tunnel session a developer actually attaches to do NOT. That
+# left `command -v generacy` failing (binary present, just not on PATH), which
+# breaks every /cockpit:* preflight and contradicts the zero-step goal
+# (generacy-ai/cluster-base#73, #69). Symlinking into /usr/local/bin at build
+# time (as root — the entrypoint runs as node and cannot write here) works
+# regardless of profile loading, unlike a ~/.bashrc/profile.d export — the same
+# reason code-server, code, and the gh wrapper live here. The links dangle only
+# during the brief boot window before the entrypoint populates the volume; once
+# the install runs they resolve through the mounted volume for all shells.
+RUN ln -sf /shared-packages/node_modules/.bin/generacy /usr/local/bin/generacy \
+ && ln -sf /shared-packages/node_modules/.bin/agency /usr/local/bin/agency
+
 # Credentials architecture: workflow subprocess isolation (v1.5)
 # See tetrad-development docs/credentials-architecture-plan.md decision #4.
 # These uids exist specifically to enforce uid-boundary isolation between the


### PR DESCRIPTION
Syncs the latest `cluster-base/develop` into cluster-microservices.

## What's included

One upstream commit: [`generacy-ai/cluster-base#74`](https://github.com/generacy-ai/cluster-base/pull/74) (fixes [cluster-base#73](https://github.com/generacy-ai/cluster-base/issues/73)).

## Why it matters

On a fresh cluster, `command -v generacy` failed in the dev-container session a developer actually uses (interactive shell / VS Code tunnel terminal), even though the binary exists at `/shared-packages/node_modules/.bin/generacy` — breaking **every `/cockpit:*` command at preflight** (`MISSING_BINARY`).

Root cause: the orchestrator entrypoint installs the CLI bins into the shared-packages volume and puts `.bin` on PATH **only for the entrypoint process**. Daemons it spawns inherit that PATH; interactive shells and the tunnel session do not.

The fix symlinks the user-facing CLIs (`generacy`, `agency`) into `/usr/local/bin` at build time, which is on PATH for every shell type regardless of profile loading — the same reason `code-server`, `code`, and the `gh` wrapper live there.

## Scope of this merge

Clean 3-way merge off the previous sync (#71/#36). The only applied change is the 16-line symlink block in `.devcontainer/generacy/Dockerfile`.

**cluster-microservices' DinD divergence is preserved.** That same Dockerfile intentionally differs from cluster-base (this repo runs its own `dockerd` via the `dind` stage + `docker-ce`/`containerd.io` + `NOPASSWD: /usr/bin/dockerd`; cluster-base is CLI-only against a mounted host socket). Verified post-merge that the `dind` stage and `FROM dind AS final` are intact and cluster-base's CLI-only stage did **not** leak in — the upstream change lands entirely in Stage 4 (the `/shared-packages` region), which is identical across both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)